### PR TITLE
Issue 4 - add certificate of deposit (CD) helper and endpoint

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -13,3 +13,16 @@
 }
 ```
 
+**GET** `/certificate_of_deposit`
++ Required parameters : `principal_amount`, `interest_rate`, `yrs`, and `compounding_per_yr`
++ Sample output
+```py
+{
+    "Tag": "Certificate of Deposit (CD)",
+    "Principal amount": 5000.0,
+    "Interest Rate": 5.0,
+    "Time in Years": 3,
+    "Number of Compounding per Year": 1,
+    "Certificate of Deposit (CD)": 5788.13,
+}
+```

--- a/helpers/functions.py
+++ b/helpers/functions.py
@@ -5,3 +5,7 @@ def simple_interest_rate(amount_paid:float, principle_amount:float, months:int):
     rate = (interest_paid*100)/(principle_amount*term)
     return rate
 
+# Function to Calculate Certificate of Deposit (CD)
+def certificate_of_deposit(principal_amount:float, interest_rate:float, yrs:int, compounding_per_yr:float):
+    cd = principal_amount * (1 + interest_rate / (100 * compounding_per_yr) ) ** (compounding_per_yr * yrs)
+    return cd

--- a/helpers/functions.py
+++ b/helpers/functions.py
@@ -6,6 +6,6 @@ def simple_interest_rate(amount_paid:float, principle_amount:float, months:int):
     return rate
 
 # Function to Calculate Certificate of Deposit (CD)
-def certificate_of_deposit(principal_amount:float, interest_rate:float, yrs:int, compounding_per_yr:float):
+def certificate_of_deposit(principal_amount:float, interest_rate:float, yrs:int, compounding_per_yr:int):
     cd = principal_amount * (1 + interest_rate / (100 * compounding_per_yr) ) ** (compounding_per_yr * yrs)
-    return cd
+    return float(cd)

--- a/main.py
+++ b/main.py
@@ -56,3 +56,23 @@ def simple_interest_rate(amount_paid: float, principle_amount: float, months: in
         }
     except:
         return HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+# Endpoints to calculate certificate of deposit (CD)
+@app.get(
+    "/cd",
+    tags=["certificate_of_deposit"],
+    description="Calculate certificate of deposit (CD)",
+)
+def certificate_of_deposit(principal_amount:float, interest_rate:float, yrs:int, compounding_per_yr:float):
+    try:
+        cd = functions.certificate_of_deposit(principal_amount, interest_rate, yrs, compounding_per_yr)
+        return {
+            "Tag": "Certificate of Deposit (CD)",
+            "Principal amount": principal_amount,
+            "Interest Rate": interest_rate,
+            "Time in Years": yrs,
+            "Number of Compounding per Year": compounding_per_yr,
+            "Certificate of Deposit (CD)": f"{cd}",
+        }
+    except:
+        return HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/main.py
+++ b/main.py
@@ -59,11 +59,11 @@ def simple_interest_rate(amount_paid: float, principle_amount: float, months: in
 
 # Endpoints to calculate certificate of deposit (CD)
 @app.get(
-    "/cd",
+    "/certificate_of_deposit",
     tags=["certificate_of_deposit"],
     description="Calculate certificate of deposit (CD)",
 )
-def certificate_of_deposit(principal_amount:float, interest_rate:float, yrs:int, compounding_per_yr:float):
+def certificate_of_deposit(principal_amount:float, interest_rate:float, yrs:int, compounding_per_yr:int):
     try:
         cd = functions.certificate_of_deposit(principal_amount, interest_rate, yrs, compounding_per_yr)
         return {

--- a/test_main.py
+++ b/test_main.py
@@ -21,3 +21,15 @@ def test_certificate_of_deposit():
             "Number of Compounding per Year":1,
             "Certificate of Deposit (CD)": "5788.125000000001"
     }
+
+#Compounding per year cannot be 0, as it is division by 0 error
+def test_certificate_of_deposit_invalid_value():
+    response = client.get("/certificate_of_deposit/?principal_amount=5000.0&interest_rate=5.0&yrs=3&compounding_per_yr=0")
+    assert response.json()["status_code"] == 500
+
+#Years cannot be a float, as it is a type error
+def test_certificate_of_deposit_invalid_type():
+    response = client.get("/certificate_of_deposit/?principal_amount=5000.0&interest_rate=5.0&yrs=3.5&compounding_per_yr=1")
+    assert response.json() == {"detail": [{"loc": ["query", "yrs"],
+            "msg": "value is not a valid integer",
+            "type": "type_error.integer"}]}

--- a/test_main.py
+++ b/test_main.py
@@ -1,0 +1,23 @@
+from main import app
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import json
+
+
+@app.get("/")
+async def read_main():
+    return {"msg": "Hello World"}
+
+client = TestClient(app)
+
+def test_certificate_of_deposit():
+    response = client.get("/certificate_of_deposit/?principal_amount=5000.0&interest_rate=5.0&yrs=3&compounding_per_yr=1")
+    assert response.status_code == 200
+
+    assert response.json() == {"Tag":"Certificate of Deposit (CD)",
+            "Principal amount":5000.0,
+            "Interest Rate":5.0,
+            "Time in Years":3,
+            "Number of Compounding per Year":1,
+            "Certificate of Deposit (CD)": "5788.125000000001"
+    }


### PR DESCRIPTION
Implemented helper function for #4 and tested with Postman (see screenshot):
- A GET endpoint is also added to `main.py` named `\certificate_of_deposit` 
- Added helper function `certificate_of_deposit()` in `function.py`
- Pytest may be added in this PR or another issue should be opened (let me know your thoughts!)

![image](https://user-images.githubusercontent.com/56566212/205464366-9804cc91-ad3b-4122-8d73-d68c5e9f8b48.png)

