### PR TITLE
Added endpoint and helper function to calculate Put-Call Parity

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -137,3 +137,18 @@
     "Interest amount": "39330.175"
 }
 ```
+
+**GET** `/put-call-parity`
+
+- Required parameters : `call_price`, `put_price` and `strike_price`
+- Sample output
+
+```py
+{
+  "Tag": "Pull Call Parity",
+  "Future Price": "800.0",
+  "Call Price": "1000.0",
+  "Put Price": "500.0",
+  "Strike Price": "300.0"
+}
+```

--- a/helpers/functions.py
+++ b/helpers/functions.py
@@ -72,3 +72,8 @@ def asset_portfolio(price_A:float, price_B:float, retrun1:float, return2:float, 
     cov = stock_correlation*standard_dev_A*standard_dev_B
     portfolio_variance = weight_A*weight_A*standard_dev_A*standard_dev_A + weight_B*weight_B*standard_dev_B*standard_dev_B + 2*weight_A*weight_B*cov
     return portfolio_variance
+
+# Function to calculate the future price in a put - call parity
+def put_call_parity(call_price:float, put_price:float, strike_price:float):
+    future_price = call_price + strike_price - put_price
+    return future_price

--- a/main.py
+++ b/main.py
@@ -291,3 +291,22 @@ def asset_portfolio(price_A:float, price_B:float, return_A:float, return_B:float
         }
     except:
         return HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+# Endpoint to Calculate Future Price in Put-Call Parity
+@app.get(
+    "/put-call-parity",
+    tags=["/put-call-parity"],
+    description="Calculate Future Price in Pull-Call Parity",
+)
+def put_call_parity(call_price:float, put_price:float, strike_price:float):
+    try:
+        future_amount = functions.put_call_parity(call_price, put_price, strike_price)
+        return {
+            "Tag": "Pull Call Parity",
+            "Future Price": f"{future_amount}",
+            "Call Price": f"{call_price}", 
+            "Put Price": f"{put_price}", 
+            "Strike Price": f"{strike_price}", 
+        }
+    except:
+        return HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## Description 
### Feature 1 (resolves issue [#5](https://github.com/Clueless-Community/fintech-api/issues/5) )
-  Added a helper function `put_call_parity`  in `functions.py` which calculated compound intrest from the provided parameters.
- Added endpoint `/put-call-parity` in `main.py` 
-  Added documentation in `ENDPOINTS.md`
- Tested endpoint in postmen


Screenshot of testing in postmen  :-
![Screenshot from 2022-12-08 14-38-58](https://user-images.githubusercontent.com/109169835/206405977-248da10b-077a-42ea-b98e-ea9ef20e3557.png)