### PR TITLE
added new helper function to calculate capital_asset_pricing_model

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -293,3 +293,18 @@
 
 }
 ```
+**GET** `/Capital_Asset_Pricing_Model`
+
+- Required parameters : `risk_free_interest_rate`, `beta_of_security`,`expected_market_return`
+- Sample Output
+```py
+{
+
+  "Tag": "Capital_Asset_Pricing_Model",
+  "risk_free_interest_rate": 2.5 + "%",
+  "beta_of_security": 1.25,
+  "expected_market_return": 7.5 + "%",
+  "Capital_Asset_Pricing_Model": "11.9%"
+
+}
+```

--- a/helpers/functions.py
+++ b/helpers/functions.py
@@ -218,3 +218,9 @@ def markup_percentage(price: float, cost: float):
 def sharpe_ratio(portfolio_return: float, risk_free_rate: float,standard_deviation_of_portfolio: float):
     sharpe_ratio = (portfolio_return - risk_free_rate)/standard_deviation_of_portfolio
     return sharpe_ratio
+
+
+# Function to calculate calculate Capital Asset Pricing Model
+def Capital_Asset_Pricing_Model(risk_free_interest_rate: float, beta_of_security: float, expected_market_return: float):
+    capital_asset_expected_return = risk_free_interest_rate + beta_of_security*(expected_market_return - risk_free_interest_rate)
+    return capital_asset_expected_return

--- a/main.py
+++ b/main.py
@@ -595,7 +595,7 @@ def sharpe_ratio(portfolio_return: float, risk_free_rate: float, standard_deviat
 )
 def Capital_Asset_Pricing_Model(risk_free_interest_rate: float, beta_of_security: float, expected_market_return: float):
     try:
-        sharpe_ratio = functions.Capital_Asset_Pricing_Model(risk_free_interest_rate,beta_of_security,expected_market_return)
+        Capital_Asset_Pricing_Model = functions.Capital_Asset_Pricing_Model(risk_free_interest_rate,beta_of_security,expected_market_return)
         return {
             "Tag": "Capital Asset Pricing Model",
             "Risk free interest rate": risk_free_interest_rate,

--- a/main.py
+++ b/main.py
@@ -585,3 +585,23 @@ def sharpe_ratio(portfolio_return: float, risk_free_rate: float, standard_deviat
         }
     except:
         return HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        
+# Endpoint to calculate Capital Asset Pricing Model
+@app.get(
+    "/Capital_Asset_Pricing_Model",
+    tags=["Capital_Asset_Pricing_Model"],
+    description="Calculating Capital Asset Pricing Model",
+)
+def Capital_Asset_Pricing_Model(risk_free_interest_rate: float, beta_of_security: float, expected_market_return: float):
+    try:
+        sharpe_ratio = functions.Capital_Asset_Pricing_Model(risk_free_interest_rate,beta_of_security,expected_market_return)
+        return {
+            "Tag": "Capital Asset Pricing Model",
+            "Risk free interest rate": risk_free_interest_rate,
+            "Beta of security": beta_of_security,
+            "Expected market return": expected_market_return,
+            "Capital asset expected return": f"{Capital_Asset_Pricing_Model}"
+        }
+    except:
+        return HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
Created a new helper function that can calculate the **capital asset pricing model** by taking risk_free_interest_rate, beta_of_security, and expected_market_return as inputs.