### PR TITLE
Add Bond Equivalent Yield Endpoint

### DIFF
--- a/ENDPOINTS.md
+++ b/ENDPOINTS.md
@@ -1632,3 +1632,17 @@ Add-function-and-endpoint-to-calculate-lump-sum-mutual-fund-investment
 
 } 
 ```
+
+**GET** `/bond_equivalent_yield`
+- required parameters : `face_value`, `purchase_price`,`days_to_maturity`
+- Sample Request: GET /bond_equivalent_yield?face_value=1000&purchase_price=900&days_to_maturity=182
+- Sample output
+```py
+{
+  "Tag": "Bond Equivalent Yield",
+  "Face value":1000,
+  "Purchase Price": 900,
+  "Days to maturity": 182,
+  "Bond Equivalent Yield (BEY)": "22.28%"
+}
+```

--- a/helpers/functions.py
+++ b/helpers/functions.py
@@ -1353,3 +1353,9 @@ def calculate_vat():
     print(f"Price (excluding VAT): {excluding_vat:.2f}")
     print(f"Price (including VAT): {including_vat:.2f}")
     print(f"VAT Amount: {vat_amount:.2f}")
+
+#Function to calculate BEY (Bond Equivalent Yield) 
+def calculate_bond_equivalent_yield(face_value, purchase_price, days_to_maturity): 
+    roi = (face_value-purchase_price)/purchase_price 
+    bey = roi * 365/days_to_maturity 
+    return bey

--- a/main.py
+++ b/main.py
@@ -2444,3 +2444,22 @@ async def calculate_vat(price: float, vat_rate: float):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="An error occurred during VAT calculation",
         )
+
+#Endpoint For calculating bond equivalent yield 
+@app.get( 
+    "/bond_equivalent_yield", 
+    tags=["bond_equivalent_yield"], 
+    description="Calculate bond equivalent yield", 
+) 
+def bond_equivalent_yield(face_value:float, purchase_price:float, days_to_maturity:int): 
+    try: 
+        bey = functions.calculate_bond_equivalent_yield(face_value,purchase_price,days_to_maturity) 
+        return { 
+            "Tag": "Bond Equivalent Yield", 
+            "Face value":face_value, 
+            "Purchase Price": purchase_price, 
+            "Days to maturity": days_to_maturity, 
+            "Bond Equivalent Yield (BEY)": f"{bey*100}%", 
+        } 
+    except: 
+        return HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## Feature
Added endpoint for calculating bond equivalent yield

## Formula
BEY = (Face Value - Purchase Price)/Purchase Price * 365/(days to maturity)

## Testing
- [x] Does not break backward compatibility
- [x] Does not show any error or warnings
- [x] Endpoint works successfully

## Endpoint
**GET** `/bond_equivalent_yield`
- required parameters : `face_value`, `purchase_price`, `days_to_maturity`
- Sample Request: GET /bond_equivalent_yield?face_value=1000&purchase_price=900&days_to_maturity=182
- Sample output
```py
{
  "Tag": "Bond Equivalent Yield",
  "Face value":1000,
  "Purchase Price": 900,
  "Days to maturity": 182,
  "Bond Equivalent Yield (BEY)": "22.28%"
}
```