### PR TITLE
calculate pension # 431

### DIFF
--- a/main.py
+++ b/main.py
@@ -319,7 +319,7 @@ def future_sip(
 def calculate_pension(
     request: calculatePension
 ):
-    return calculate_pension_task(request.current_age, request.retirement_age, request.current_salary, request.percentage_saved, request.employer_match, request.expected_annual_raise, request.savings_goal)
+    return calculate_pension_task(request.monthly_investment_amount, request.no_of_years, request.annuity_rates, request.annuity_purchased, request.yearly_interest_rates)
 
 
 # endpoint for payback period


### PR DESCRIPTION
calculate pension is showing 500 server not found error. 

@ighoshsubho 

calculate_pension_task( --- here 7 parameters passed ------) but in that function 5 parameters passed.
in basemodel also 5 arguments passed. not matching with calculate_pension_task().

i edited the attributes. 

but please check the result is correct or not.