### PR TITLE
fix: typo from 'fintect' to 'fintech'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ cd fintech-api
 
 > Folder Structure
 ```
-fintect-api
+fintech-api
 │
 └───📂helpers
 │   │   { Python functions for different calculations }


### PR DESCRIPTION
Just while scrolling through the readme found this typo which some contributor might have made.
<img width="922" alt="image" src="https://github.com/Clueless-Community/fintech-api/assets/100852245/1ca58014-bdb0-40a4-afad-667d4956136d">
